### PR TITLE
Fix bug #68684

### DIFF
--- a/Sources/OneDriveHelper.swift
+++ b/Sources/OneDriveHelper.swift
@@ -221,7 +221,6 @@ extension OneDriveFileProvider {
         let maximumSize: Int64 = 10_485_760 // Recommended by OneDrive documentations and divides evenly by 320 KiB, max 60MiB.
         var request = URLRequest(url: url)
         request.httpMethod = "PUT"
-        request.setValue(authentication: self.credential, with: .oAuth2)
         
         let finalRange: Range<Int64>
         if let range = range {


### PR DESCRIPTION
https://learn.microsoft.com/en-us/graph/api/driveitem-createuploadsession?view=graph-rest-1.0
If you include the Authorization header when issuing the PUT call, it may result in an HTTP 401 Unauthorized response. Only send the Authorization header and bearer token when issuing the POST during the first step. Don't include it when you issue the PUT call.